### PR TITLE
When moving to a bookmark from the Notes dialog, the review cursor do…

### DIFF
--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -114,7 +114,10 @@ def moveToBookmark(position):
 			obj=treeInterceptor
 		info = obj.makeTextInfo(textInfos.POSITION_FIRST)
 		info.move(textInfos.UNIT_CHARACTER, position)
-		info.updateCaret()
+		if hasattr(obj,'selection'):
+			obj.selection=info
+		else:
+			info.updateCaret()
 		speech.cancelSpeech()
 		info.move(textInfos.UNIT_LINE,1,endPoint="end")
 		speech.speakTextInfo(info,reason=controlTypes.REASON_CARET)

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("Add-on for setting place markers on specific virtual documents"),
 	# version
-	"addon_version" : "8.0",
+	"addon_version" : "9.0-dev-i6",
 	# Author(s)
 	"addon_author" : u"Noelia <nrm1977@gmail.com>, Chris <llajta2012@gmail.com>",
 	# URL for the add-on documentation support


### PR DESCRIPTION
…esn't follow system cursor

Instead of using info.updateCaret(), when possible, set object.selection = info.