### PR TITLE
Migrate saved place markers when addon is updated

### DIFF
--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -23,7 +23,6 @@ def onInstall():
 	addonDir = os.path.dirname(__file__)
 	placeMarkersPath = os.path.join(addonDir, "globalPlugins", "placeMarkers", "savedPlaceMarkers")
 	addonBackupPath = os.path.join(configPath, "placeMarkersBackup")
-	previousPlaceMarkersPath = os.path.join(configPath, "addons", "placeMarkers", "globalPlugins", "placeMarkers", "savedPlaceMarkers")
 	if os.path.isdir(addonBackupPath):
 		if gui.messageBox(
 			# Translators: label of a dialog presented when installing this addon and placeMarkersBackup is found.
@@ -33,5 +32,6 @@ def onInstall():
 			wx.YES|wx.NO|wx.ICON_WARNING)==wx.YES:
 				copyTree(addonBackupPath, placeMarkersPath)
 				return
-	if os.path.isdir(previousPlaceMarkersPath):
+	previousPlaceMarkersPath = os.path.join(configPath, "addons", "placeMarkers", "globalPlugins", "placeMarkers", "savedPlaceMarkers")
+				if os.path.isdir(previousPlaceMarkersPath):
 		copyTree(previousPlaceMarkersPath, placeMarkersPath)

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -12,10 +12,23 @@ import wx
 
 addonHandler.initTranslation()
 
+def moveTree(src, dst, clearDst=0):
+	if clearDst and os.path.isdir(dst):
+		shutil.rmtree(dst, ignore_errors=False)
+	try:
+		shutil.copytree(src, dst)
+	except IOError:
+		pass
+
 def onInstall():
 	configPath = globalVars.appArgs.configPath
-	addonPath = os.path.join(configPath, "placeMarkersBackup")
-	if not os.path.isdir(addonPath):
+	addonDir = os.path.dirname(__file__)
+	placeMarkersPath = os.path.join(addonDir, "globalPlugins", "placeMarkers", "savedPlaceMarkers")
+	addonBackupPath = os.path.join(configPath, "placeMarkersBackup")
+	previousPlaceMarkersPath = os.path.join(configPath, "addons", "placeMarkers", "globalPlugins", "placeMarkers", "savedPlaceMarkers")
+	if os.path.isdir(previousPlaceMarkersPath):
+		moveTree(previousPlaceMarkersPath, placeMarkersPath)
+	if not os.path.isdir(addonBackupPath):
 		return
 	if gui.messageBox(
 	# Translators: label of a dialog presented when installing this addon and placeMarkersBackup is found.
@@ -23,9 +36,4 @@ def onInstall():
 	# Translators: title of a dialog presented when installing this addon and placeMarkersBackup is found.
 	_("Install or update add-on"),
 	wx.YES|wx.NO|wx.ICON_WARNING)==wx.YES:
-		addonDir = os.path.dirname(__file__)
-		placeMarkersPath = os.path.join(addonDir, "globalPlugins", "placeMarkers", "savedPlaceMarkers")
-		try:
-			shutil.copytree(addonPath, placeMarkersPath)
-		except IOError:
-			pass
+		moveTree(addonBackupPath, placeMarkersPath, 1)

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # installTasks for placeMarkers add-on
-#Copyright (C) 2016,2019 Noelia Ruiz Martínez, Łukasz Golonka
+#Copyright (C) 2016-2019 Noelia Ruiz Martínez, Łukasz Golonka
 # Released under GPL 2
 
 import addonHandler

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -12,9 +12,7 @@ import wx
 
 addonHandler.initTranslation()
 
-def moveTree(src, dst, clearDst=0):
-	if clearDst and os.path.isdir(dst):
-		shutil.rmtree(dst, ignore_errors=False)
+def copyTree(src, dst):
 	try:
 		shutil.copytree(src, dst)
 	except IOError:
@@ -26,14 +24,14 @@ def onInstall():
 	placeMarkersPath = os.path.join(addonDir, "globalPlugins", "placeMarkers", "savedPlaceMarkers")
 	addonBackupPath = os.path.join(configPath, "placeMarkersBackup")
 	previousPlaceMarkersPath = os.path.join(configPath, "addons", "placeMarkers", "globalPlugins", "placeMarkers", "savedPlaceMarkers")
+	if os.path.isdir(addonBackupPath):
+		if gui.messageBox(
+			# Translators: label of a dialog presented when installing this addon and placeMarkersBackup is found.
+			_("Your configuration folder for NVDA contains files that seem to be derived from a previous version of this add-on. Do you want to update it?"),
+			# Translators: title of a dialog presented when installing this addon and placeMarkersBackup is found.
+			_("Install or update add-on"),
+			wx.YES|wx.NO|wx.ICON_WARNING)==wx.YES:
+				copyTree(addonBackupPath, placeMarkersPath)
+				return
 	if os.path.isdir(previousPlaceMarkersPath):
-		moveTree(previousPlaceMarkersPath, placeMarkersPath)
-	if not os.path.isdir(addonBackupPath):
-		return
-	if gui.messageBox(
-	# Translators: label of a dialog presented when installing this addon and placeMarkersBackup is found.
-	_("Your configuration folder for NVDA contains files that seem to be derived from a previous version of this add-on. Do you want to update it?"),
-	# Translators: title of a dialog presented when installing this addon and placeMarkersBackup is found.
-	_("Install or update add-on"),
-	wx.YES|wx.NO|wx.ICON_WARNING)==wx.YES:
-		moveTree(addonBackupPath, placeMarkersPath, 1)
+		copyTree(previousPlaceMarkersPath, placeMarkersPath)

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # installTasks for placeMarkers add-on
-#Copyright (C) 2016 Noelia Ruiz Martínez
+#Copyright (C) 2016,2019 Noelia Ruiz Martínez, Łukasz Golonka
 # Released under GPL 2
 
 import addonHandler
@@ -33,5 +33,5 @@ def onInstall():
 				copyTree(addonBackupPath, placeMarkersPath)
 				return
 	previousPlaceMarkersPath = os.path.join(configPath, "addons", "placeMarkers", "globalPlugins", "placeMarkers", "savedPlaceMarkers")
-				if os.path.isdir(previousPlaceMarkersPath):
+	if os.path.isdir(previousPlaceMarkersPath):
 		copyTree(previousPlaceMarkersPath, placeMarkersPath)


### PR DESCRIPTION
Closes #16  
## Description of the problem
During update of the add-on saved data is deleted. The only way to retain it is to perform a backup in advance.
## Chosen solution
When installing first move configuration folder from previous version if it exists, and then if backup  has been performed overwrite it with backed up data.
## Testing performed
1. Installation without previous version and without backup  - works
2. Installation without previous version and with backup present - works.
3. Installation with previous version containing some place markers and without a backup - works - data is migrated correctly.
4. Installation with both saved place markers in the previous version and with backup performed - after installation the backup data is migrated. I've written it this way because if someone performs a backup he probably wants copied data not the config for the previous version.