### PR TITLE
Linter error in __init__ to testing the workflow of the GitHub Actions

### DIFF
--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -204,7 +204,7 @@ def getSavedBookmarks():
 
 class SpecificSearchDialog(wx.Dialog):
 
-	def __init__(self, parent, reverse=False):
+	def __init__(self,parent,reverse=False):
 		# Translators: The title of the Specific Search dialog.
 		super(SpecificSearchDialog, self).__init__(parent, title=_("Specific search"))
 		self.searchFile = getFileSearch()

--- a/addon/globalPlugins/placeMarkers/skipTranslation.py
+++ b/addon/globalPlugins/placeMarkers/skipTranslation.py
@@ -1,9 +1,9 @@
-# -*- coding: UTF-8 -*-
+﻿# -*- coding: UTF-8 -*-
 # skipTranslation: Module to get translated texts from NVDA
 # Based on implementation made by Alberto Buffolino
 # https://github.com/nvaccess/nvda/issues/4652
 #Copyright (C) 2016 Noelia Ruiz Martínez
 # Released under GPL 2
 
-def translate(text):
+def translate(text:str):
 	return _(text)


### PR DESCRIPTION
Hi Noelia,  

Thank you for your work!  
I created a PR with a linter error to testing the workflow of the GitHub Actions.  

I just removed the spaces between the arguments of the constructor (in class SpecificSearchDialog).  

Good luck!
Oleksandr
