### PR TITLE
Fix stranslatable strings

### DIFF
--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -712,7 +712,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	@script(
 		# Translators: message presented in input mode, when a keystroke of an addon script is pressed.
-		description=_("Activates the Copy dialog of %s." % ADDON_SUMMARY)
+		description=_("Activates the Copy dialog of %s.") % ADDON_SUMMARY
 	)
 	def script_activateCopyDialog(self, gesture):
 		wx.CallAfter(self.onCopy, None)
@@ -725,7 +725,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	@script(
 		# Translators: message presented in input mode, when a keystroke of an addon script is pressed.
-		description=_("Activates the Restore dialog of %s." % ADDON_SUMMARY)
+		description=_("Activates the Restore dialog of %s.") % ADDON_SUMMARY
 	)
 	def script_activateRestoreDialog(self, gesture):
 		wx.CallAfter(self.onRestore, None)
@@ -1030,7 +1030,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		fileName = getFile("bookmarks")
 		ui.browseableMessage(
 			# Translators: Title for a message presented when the file name for place markers is shown in browse mode.
-			fileName, _("%s file" % ADDON_SUMMARY)
+			fileName, _("%s file") % ADDON_SUMMARY
 		)
 
 	@script(


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Translations for strings containing %s as a reference to addon summary don't work.
### Description of how this pull request fixes the issue:
Put % ADDON_SUMMARY outside the gettext message, since addon summary is a translated string.
### Testing performed:
- Confirm that translations work locally.
### Known issues with pull request:
None
### Change log entry:
* Fixed translated strings making translations to work properly.