### PR TITLE
Report if the current document has placeMarkers

### DIFF
--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -1027,10 +1027,19 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			):
 				gesture.send()
 				return
-		fileName = getFile("bookmarks")
+		message = getFile("bookmarks")
+		if os.path.isfile(getFileBookmarks()):
+			# Translators: Presented when the current document has positional bookmarks.
+			message += "\r\n\r\n" + _("Has bookmarks.")
+		if os.path.isfile(getFileSearch()):
+			# Translators: Presented when the current document has specific search.
+			message += "\r\n\r\n" + _("Has text for specific search.")
+		if os.path.isfile(getFileTempBookmark()):
+			# Translators: Presented when the current document has a temporary bookmark.
+			message += "\r\n\r\n" + _("Has temporary bookmark.")
 		ui.browseableMessage(
-			# Translators: Title for a message presented when the file name for place markers is shown in browse mode.
-			fileName, _("%s file") % ADDON_SUMMARY
+					# Translators: Title for a message presented when the file name for place markers is shown in browse mode.
+			message, _("%s file") % ADDON_SUMMARY
 		)
 
 	@script(

--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -1038,7 +1038,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			# Translators: Presented when the current document has a temporary bookmark.
 			message += "\r\n\r\n" + _("Has temporary bookmark.")
 		ui.browseableMessage(
-					# Translators: Title for a message presented when the file name for place markers is shown in browse mode.
+			# Translators: Title for a message presented when the file name for place markers is shown in browse mode.
 			message, _("%s file") % ADDON_SUMMARY
 		)
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -47,3 +47,14 @@ i18nSources = pythonSources + ["buildVars.py"]
 # Files that will be ignored when building the nvda-addon file
 # Paths are relative to the addon directory, not to the root directory of your addon sources.
 excludedFiles = []
+# Base language for the NVDA add-on
+# If your add-on is written in a language other than english,  modify this variable.
+# For example, set baseLanguage to "es" if your add-on is primarily written in spanish.
+baseLanguage = "en"
+
+# Markdown extensions for add-on documentation
+# Most add-ons do not require additional Markdown extensions.
+# If you need to add support for markup such as tables, fill out the below list.
+# Extensions string must be of the form "markdown.extensions.extensionName"
+# e.g. "markdown.extensions.tables" to add tables.
+markdownExtensions = []


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Fixes issue #32 
### Summary of the issue:
Add ability to see if the current document has placeMarkers.
### Description of how this pull request fixes the issue:
In the message shown to see the path of placeMarkers for the current document, reflect if there are positional bookmarks, text for specific search or temporary bookmark.
### Testing performed:
Tested locally addin bookmarks, text for specific search and a temporary bookmark in Google webpage.
### Known issues with pull request:
None
### Change log entry:
* The command to see the path for placeMarkers shows if there are bookmarks, text for specific search or a temporary bookmark for the current document.