### PR TITLE
Don't allow the add-on to be run on secure screens

### DIFF
--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -635,6 +635,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	scriptCategory = ADDON_SUMMARY
 
 	def __init__(self):
+		if globalVars.appArgs.secure:
+			return
 		super(GlobalPlugin, self).__init__()
 		self.menu = gui.mainFrame.sysTrayIcon.preferencesMenu
 		self.BSMenu = wx.Menu()


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
The add-on shouldn't give access to Windows Explorer on secure screens. Also, it can save/modify files containing placeMarkers, and I don't know use cases where it can be useful on secure screens.
### Description of how this pull request fixes the issue:
The plugin won't be run on secure screens. This is achieved with the following code on the __init__ method:

`if globalVars.appArgs.secure: return`
### Testing performed:
Tested on a secure screen and with NVDA Python console:

```
import globalVars
globalVars.appArgs.secure = True
```
### Known issues with pull request:
None
### Change log entry:
* The add-on cannot be used on secure screens.