### PR TITLE
Save bookmarks with UIA enabled in browsers, and handle exceptions

### DIFF
--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -20,6 +20,7 @@ import globalVars
 import textInfos
 from textInfos.offsets import Offsets
 from browseMode import BrowseModeDocumentTreeInterceptor
+import NVDAObjects
 import controlTypes
 import gui
 from gui import guiHelper
@@ -141,7 +142,14 @@ def moveToBookmark(position):
 	if isinstance(treeInterceptor, BrowseModeDocumentTreeInterceptor) and not treeInterceptor.passThrough:
 		obj = treeInterceptor
 		bookmark = Offsets(position, position)
-		info = obj.makeTextInfo(bookmark)
+		try:
+			info = obj.makeTextInfo(bookmark)
+		except ValueError as e:
+			if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor):
+				# Translators: message presented when cannot move to bookmarks due to UIA.
+				ui.message(_("Cannot move to bookmark with UIA enabled for your browser"))
+				return
+			raise e
 		obj._set_selection(info)
 		speech.cancelSpeech()
 		info.move(textInfos.UNIT_LINE, 1, endPoint="end")
@@ -857,21 +865,31 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		else:
 			gesture.send()
 			return
-		bookmark = obj.makeTextInfo(textInfos.POSITION_CARET).bookmark
+		# Code for UIA provided by Abdel (@abdel792)
+		if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor) and not obj.passThrough:
+			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
+			# To point to where the browse mode caret is located, as there really isn't a real caret, we can use the selection attribute as follows:
+			cur = obj.selection
+			cur.expand(textInfos.UNIT_LINE)
+			first.setEndPoint(cur, "endToStart")
+			startOffset = len(first.text)
+		else:
+			bookmark = obj.makeTextInfo(textInfos.POSITION_CARET).bookmark
+			startOffset = bookmark.startOffset
 		bookmarks = getSavedBookmarks()
 		noteTitle = obj.makeTextInfo(textInfos.POSITION_SELECTION).text[:100]
-		if bookmark.startOffset in bookmarks:
-			noteBody = bookmarks[bookmark.startOffset].body
+		if startOffset in bookmarks:
+			noteBody = bookmarks[startOffset].body
 		else:
 			noteBody = ""
-		bookmarks[bookmark.startOffset] = Note(noteTitle, noteBody)
+		bookmarks[startOffset] = Note(noteTitle, noteBody)
 		fileName = getFileBookmarks()
 		try:
 			with open(fileName, "wb") as f:
 				pickle.dump(bookmarks, f, protocol=0)
 			ui.message(
 				# Translators: message presented when a position is saved as a bookmark.
-				_("Saved position at character %d") % bookmark.startOffset
+				_("Saved position at character %d") % startOffset
 			)
 		except Exception as e:
 			log.debugWarning("Error saving bookmark", exc_info=True)
@@ -901,14 +919,23 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				_("No bookmarks")
 			)
 			return
-		curPos = obj.makeTextInfo(textInfos.POSITION_CARET).bookmark.startOffset
-		if curPos not in bookmarks:
+		if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor) and not obj.passThrough:
+			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
+			# To point to where the browse mode caret is located, as there really isn't a real caret, we can use the selection attribute as follows:
+			cur = obj.selection
+			cur.expand(textInfos.UNIT_LINE)
+			first.setEndPoint(cur, "endToStart")
+			startOffset = len(first.text)
+		else:
+			bookmark = obj.makeTextInfo(textInfos.POSITION_CARET).bookmark
+			startOffset = bookmark.startOffset
+		if startOffset not in bookmarks:
 			ui.message(
 				# Translators: message presented when the current document has bookmarks, but none is selected.
 				_("No bookmark selected")
 			)
 			return
-		del(bookmarks[curPos])
+		del(bookmarks[startOffset])
 		fileName = getFileBookmarks()
 		if bookmarks != {}:
 			try:
@@ -962,7 +989,14 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				_("No bookmarks found")
 			)
 			return
-		curPos = obj.makeTextInfo(textInfos.POSITION_CARET).bookmark.startOffset
+		try:
+			curPos = obj.makeTextInfo(textInfos.POSITION_CARET).bookmark.startOffset
+		except AttributeError as e:
+			if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor) and not obj.passThrough:
+				# Translators: message presented when cannot move to bookmarks due to UIA.
+				ui.message(_("Cannot move to bookmark with UIA enabled for your browser"))
+				return
+			raise e
 		nextPos = None
 		for pos in sorted(bookmarks):
 			if pos > curPos:
@@ -1006,7 +1040,14 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				_("No bookmarks found")
 			)
 			return
-		curPos = obj.makeTextInfo(textInfos.POSITION_CARET).bookmark.startOffset
+		try:
+			curPos = obj.makeTextInfo(textInfos.POSITION_CARET).bookmark.startOffset
+		except AttributeError as e:
+			if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor) and not obj.passThrough:
+				# Translators: message presented when cannot move to bookmarks due to UIA.
+				ui.message(_("Cannot move to bookmark with UIA enabled for your browser"))
+				return
+			raise e
 		prevPos = None
 		for pos in sorted(bookmarks, reverse=True):
 			if pos < curPos:

--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -868,7 +868,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# Code for UIA provided by Abdel (@abdel792)
 		if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor):
 			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
-			# To point to where the browse mode caret is located, as there really isn't a real caret, we can use the selection attribute
 			cur = obj.selection
 			cur.expand(textInfos.UNIT_LINE)
 			first.setEndPoint(cur, "endToStart")
@@ -921,7 +920,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return
 		if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor):
 			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
-			# To point to where the browse mode caret is located, as there really isn't a real caret, we can use the selection attribute
 			cur = obj.selection
 			cur.expand(textInfos.UNIT_LINE)
 			first.setEndPoint(cur, "endToStart")

--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -866,9 +866,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			gesture.send()
 			return
 		# Code for UIA provided by Abdel (@abdel792)
-		if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor) and not obj.passThrough:
+		if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor):
 			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
-			# To point to where the browse mode caret is located, as there really isn't a real caret, we can use the selection attribute as follows:
+			# To point to where the browse mode caret is located, as there really isn't a real caret, we can use the selection attribute
 			cur = obj.selection
 			cur.expand(textInfos.UNIT_LINE)
 			first.setEndPoint(cur, "endToStart")
@@ -919,9 +919,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				_("No bookmarks")
 			)
 			return
-		if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor) and not obj.passThrough:
+		if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor):
 			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
-			# To point to where the browse mode caret is located, as there really isn't a real caret, we can use the selection attribute as follows:
+			# To point to where the browse mode caret is located, as there really isn't a real caret, we can use the selection attribute
 			cur = obj.selection
 			cur.expand(textInfos.UNIT_LINE)
 			first.setEndPoint(cur, "endToStart")
@@ -992,7 +992,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		try:
 			curPos = obj.makeTextInfo(textInfos.POSITION_CARET).bookmark.startOffset
 		except AttributeError as e:
-			if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor) and not obj.passThrough:
+			if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor):
 				# Translators: message presented when cannot move to bookmarks due to UIA.
 				ui.message(_("Cannot move to bookmark with UIA enabled for your browser"))
 				return
@@ -1043,7 +1043,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		try:
 			curPos = obj.makeTextInfo(textInfos.POSITION_CARET).bookmark.startOffset
 		except AttributeError as e:
-			if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor) and not obj.passThrough:
+			if isinstance(treeInterceptor, NVDAObjects.UIA.chromium.ChromiumUIATreeInterceptor):
 				# Translators: message presented when cannot move to bookmarks due to UIA.
 				ui.message(_("Cannot move to bookmark with UIA enabled for your browser"))
 				return

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,9 @@ Using the Place markers submenu under NVDA's Preferences menu, you can access:
 
 Note: The bookmark position is based on the number of characters; and therefore in dynamic pages it is better to use the specific search, not bookmarks.
 
+## Changes for 21.0
+* Bookmarks can be saved with UIA enabled in browsers based on Chromium, thanks to Abdel.
+
 ## Changes for 20.0
 * Requires NVDA 2022.1 or later.
 


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
Currently, it's not possible to save bookmarks with UIA enabled for browsers based on Chromium.
### Description of how this pull request fixes the issue:
We used code provided by @abdel792 in this [message posted on the add-ons mailing list](https://nvda-addons.groups.io/g/nvda-addons/message/19192).

Also, exceptions are handled when cannot move to bookmarks due to UIA, informing with ui.message.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
* Bookmarks can be saved with UIA enabled in browsers based on Chromium, thanks to Abdel.