### PR TITLE
Fix regression: work again with MS Word

### DIFF
--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -253,7 +253,10 @@ def moveToBookmark(position):
 	treeInterceptor = obj.treeInterceptor
 	if isinstance(treeInterceptor, BrowseModeDocumentTreeInterceptor) and not treeInterceptor.passThrough:
 		obj = treeInterceptor
-		if isinstance(obj, chromium.ChromiumUIATreeInterceptor):
+		if (
+			isinstance(obj, chromium.ChromiumUIATreeInterceptor)
+			or isinstance(obj, UIAHandler.browseMode.UIADocumentWithTableNavigation)
+		):
 			goToUIABookmark(obj, position)
 		else:
 			goToNonUIABookmark(obj, position)
@@ -287,7 +290,10 @@ def getFile(folder, ext=""):
 		if rootObj and treeInterceptor and isinstance(treeInterceptor, chromium.ChromiumUIATreeInterceptor):
 			uia = True
 			val = rootObj.UIAValuePattern.CurrentValue
-		nameToAdd = " - %s" % val.split("#")[0].split("/")[-1].split("\\")[-1]
+		try:
+			nameToAdd = " - %s" % val.split("#")[0].split("/")[-1].split("\\")[-1]
+		except Exception:
+			nameToAdd = ""
 	else:
 		nameToAdd = ""
 	file = file.rsplit(" - ", 1)[0]
@@ -986,7 +992,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			gesture.send()
 			return
 		# Code for UIA provided by Abdel(@abdel792)
-		if isinstance(treeInterceptor, chromium.ChromiumUIATreeInterceptor):
+		if (
+			isinstance(treeInterceptor, chromium.ChromiumUIATreeInterceptor)
+			or isinstance(treeInterceptor, UIAHandler.browseMode.UIADocumentWithTableNavigation)
+		):
 			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
 			cur = obj.selection
 			first.setEndPoint(cur, "endToStart")
@@ -1105,7 +1114,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				_("No bookmarks found")
 			)
 			return
-		if isinstance(obj, chromium.ChromiumUIATreeInterceptor):
+		if (
+			isinstance(obj, chromium.ChromiumUIATreeInterceptor)
+			or isinstance (obj, UIAHandler.browseMode.UIADocumentWithTableNavigation)
+		):
 			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
 			cur = obj.selection
 			first.setEndPoint(cur, "endToStart")
@@ -1155,7 +1167,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				_("No bookmarks found")
 			)
 			return
-		if isinstance(obj, chromium.ChromiumUIATreeInterceptor):
+		if (
+			isinstance(obj, chromium.ChromiumUIATreeInterceptor)
+			or isinstance (obj, UIAHandler.browseMode.UIADocumentWithTableNavigation)
+		):
 			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
 			cur = obj.selection
 			first.setEndPoint(cur, "endToStart")

--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -1116,7 +1116,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return
 		if (
 			isinstance(obj, chromium.ChromiumUIATreeInterceptor)
-			or isinstance (obj, UIAHandler.browseMode.UIADocumentWithTableNavigation)
+			or isinstance(obj, UIAHandler.browseMode.UIADocumentWithTableNavigation)
 		):
 			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
 			cur = obj.selection
@@ -1169,7 +1169,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return
 		if (
 			isinstance(obj, chromium.ChromiumUIATreeInterceptor)
-			or isinstance (obj, UIAHandler.browseMode.UIADocumentWithTableNavigation)
+			or isinstance(obj, UIAHandler.browseMode.UIADocumentWithTableNavigation)
 		):
 			first = obj.makeTextInfo(textInfos.POSITION_FIRST)
 			cur = obj.selection

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,9 @@ Using the Place markers submenu under NVDA's Preferences menu, you can access:
 
 Note: The bookmark position is based on the number of characters; and therefore in dynamic pages it is better to use the specific search, not bookmarks.
 
+## Changes for 23.0
+* The add-on works again with Microsoft Word.
+
 ## Changes for 22.0
 * We can move to bookmarks and delete them with UIA enabled, thanks to Abdel.
 


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None. Reported by Marco Oros:

https://nvda-addons.groups.io/g/nvda-addons/topic/93454844

### Summary of the issue:
The add-on doesn't work in Microsoft Word.
### Description of how this pull request fixes the issue:
- Use try... except when determining nameToAdd
- In addition to Chromium, consider isinstance (obj, UIAHandler.browseMode.UIADocumentWithTableNavigation)
### Testing performed:
Tested locally with and without UIA setting enabled in NVDA.
### Known issues with pull request:
None
### Change log entry:
* The add-on works again in Microsoft Word.