### PR TITLE
Compatibility with NVDA 2023.1

### DIFF
--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -957,7 +957,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	@script(
 		# Translators: message presented in input mode, when a keystroke of an addon script is pressed.
 		description=_("Show the Notes dialog for a specific document."),
-		gesture="kb:NVDA+alt+k"
+		gesture="kb:NVDA+alt+y"
 	)
 	def script_activateNotesDialog(self, gesture):
 		obj = api.getFocusObject()
@@ -977,7 +977,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	@script(
 		# Translators: message presented in input mode, when a keystroke of an addon script is pressed.
 		description=_("Saves the current position as a bookmark."),
-		gesture="kb:NVDA+control+shift+k"
+		gesture="kb:NVDA+control+shift+y"
 	)
 	def script_saveBookmark(self, gesture):
 		obj = api.getFocusObject()
@@ -1093,7 +1093,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# Translators: message presented in input mode, when a keystroke of an addon script is pressed.
 		description=_("Moves to the next bookmark."),
 		resumeSayAllMode=sayAll.CURSOR.CARET,
-		gesture="kb:NVDA+k"
+		gesture="kb:NVDA+y"
 	)
 	def script_selectNextBookmark(self, gesture):
 		obj = api.getFocusObject()
@@ -1146,7 +1146,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# Translators: message presented in input mode, when a keystroke of an addon script is pressed.
 		description=_("Moves to the previous bookmark."),
 		resumeSayAllMode=sayAll.CURSOR.CARET,
-		gesture="kb:NVDA+shift+k"
+		gesture="kb:NVDA+shift+y"
 	)
 	def script_selectPreviousBookmark(self, gesture):
 		obj = api.getFocusObject()

--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # placeMarkers: Plugin to manage place markers based on positions or strings in specific documents
-# Copyright (C) 2012-2022 Noelia Ruiz Martínez, other contributors
+# Copyright (C) 2012-2023 Noelia Ruiz Martínez, other contributors
 # Released under GPL 2
 # Converted to Python 3 by Joseph Lee in 2017
 # UIA support added by Abdel in 2022

--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion": "2022.1",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2022.4",
+	"addon_lastTestedNVDAVersion": "2023.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }

--- a/readme.md
+++ b/readme.md
@@ -11,12 +11,12 @@ This addon is based on SpecificSearch and Bookmark&Search, developed by the same
 ## Key Commands: ##
 
 *	control+shift+NVDA+f: Opens a dialog with an edit box that shows the last saved search; in this dialog you can also select the previously saved searches from a combo box or remove the selected string from the history using a checkbox. You can choose if the text contained in the edit box will be added to the history of your saved texts. Finally, choose an action from the next group of radio buttons (between Search next, Search previous or Don't search), and specify if NVDA will make a case sensitive search. When you press okay, NVDA will search for this string.
-*	control+shift+NVDA+k: Saves the current position as a bookmark. If you want to provide a name for this bookmark, select some text from this position before saving it.
+*	control+shift+NVDA+y: Saves the current position as a bookmark. If you want to provide a name for this bookmark, select some text from this position before saving it.
 *	control+shift+NVDA+delete: Deletes the bookmark corresponding to this position.
-*	NVDA+k: Moves to the next bookmark.
-*	shift+NVDA+k: Moves to the previous bookmark.
+*	NVDA+y: Moves to the next bookmark.
+*	shift+NVDA+y: Moves to the previous bookmark.
 *	Not assigned: Shows the file name where the place markers data will be saved in browse mode, without an extension.
-*	alt+NVDA+k: Opens a dialog with the bookmarks saved for this document. You can write a note for each bookmark; press Save note to save changes. Pressing Delete you can remove the selected bookmark. Pressing OK you can move to the selected position.
+*	alt+NVDA+y: Opens a dialog with the bookmarks saved for this document. You can write a note for each bookmark; press Save note to save changes. Pressing Delete you can remove the selected bookmark. Pressing OK you can move to the selected position.
 *	Not assigned: Saves a position as a temporary bookmark.
 *	Not assigned: Moves to the temporary bookmark for the current document.
 *	Not assigned: Finds the next occurrence of the last text searched for any specific document.
@@ -33,6 +33,10 @@ Using the Place markers submenu under NVDA's Preferences menu, you can access:
 *	Restore placeMarkers: You can restore your bookmarks from a previously saved placeMarkers folder.
 
 Note: The bookmark position is based on the number of characters; and therefore in dynamic pages it is better to use the specific search, not bookmarks.
+
+## Changes for 24.0
+* Y is used instead of k in gestures such as NVDA+k, NVDA+shift+k, NVDA+alt+k and NVDA+control+shift+k.
+* Compatible with NVDA 2023.1.
 
 ## Changes for 23.0
 * The add-on works again with Microsoft Word.


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
NVDA+k is a command of NVDA 2023.1, and the add-on needs to be updated for compatibility.
### Description of how this pull request fixes the issue:
K has been replaced with y in gestures.
### Testing performed:
Not tested yet.
### Known issues with pull request:
None.
### Change log entry:
* Y instead of k is used in gestures.
* Compatible with NVDA 2023.1.