### PR TITLE
removeUrlParams

### DIFF
--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -292,7 +292,7 @@ def getFile(folder, ext=""):
 			uia = True
 			val = rootObj.UIAValuePattern.CurrentValue
 		try:
-			nameToAdd = " - %s" % val.split("#")[0].split("/")[-1].split("\\")[-1]
+			nameToAdd = " - %s" % val.split("#")[0].split("?")[0].split("/")[-1].split("\\")[-1]
 		except Exception:
 			nameToAdd = ""
 	else:

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,9 @@ Using the PlaceMarkers submenu under NVDA's Preferences menu, you can access:
 
 Note: The placemarker position is based on the number of characters; and therefore in dynamic pages it is better to use the specific search, not placemarkers.
 
+## Changes for 35.0
+* Removed URL parameters from file names, so that bookmarks are valid for specific websites in different sessions.
+
 ## Changes for 24.0
 * Y is used instead of k in gestures such as NVDA+k, NVDA+shift+k, NVDA+alt+k and NVDA+control+shift+k.
 * Compatible with NVDA 2023.1.


### PR DESCRIPTION
- Remove URL paramsafter question mark, so they aren't considered whencreating placeMarkers files
- Update readme

<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None, reported privately.
### Summary of the issue:
URL parameters after question mark are considered when saving bookmarks. This may make bookmarks invalid for the same website between different sessions.
### Description of how this pull request fixes the issue:
Remove characters after the question mark when calculating files where bookmarks are placed.
### Testing performed:
Tested locally in DuckDuckGo webpage, and tested by the reporter.
### Known issues with pull request:
Previously calculation of bookmark files considered URL parameters. If someone wants to switch to the previous behavior, an add-on settings panel maybe use to select this.
### Change log entry:
* Removed URL parameters from file names, so that bookmarks are valid for specific websites in different sessions.
