### PR TITLE
Suspend profile triggers in dialogs, according to NVDA behavior in 2025.2

### DIFF
--- a/addon/globalPlugins/placeMarkers/__init__.py
+++ b/addon/globalPlugins/placeMarkers/__init__.py
@@ -383,6 +383,9 @@ def getSavedBookmarks():
 
 
 class SpecificSearchDialog(wx.Dialog):
+
+	shouldSuspendConfigProfileTriggers = True
+
 	def __init__(self, parent, reverse=False):
 		# Translators: The title of the Specific Search dialog.
 		super(SpecificSearchDialog, self).__init__(parent, title=_("Specific search"))
@@ -540,6 +543,9 @@ def doRestore(restoreDirectory):
 
 
 class NotesDialog(wx.Dialog):
+
+	shouldSuspendConfigProfileTriggers = True
+
 	def __init__(self, parent, fileName):
 		# Translators: The title of the Notes dialog.
 		super(NotesDialog, self).__init__(parent, title=_("Notes"))

--- a/buildVars.py
+++ b/buildVars.py
@@ -27,9 +27,9 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion": "2025.1",
+	"addon_minimumNVDAVersion": "2025.2",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2025.1.2",
+	"addon_lastTestedNVDAVersion": "2025.2",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None.
### Summary of the issue:
N¡In NVDA 2025.2, profile triggers are suspended in dialogs opened when browse mode is active.
### Description of how this pull request fixes the issue:
Use `	shouldSuspendConfigProfileTriggers = True` in Specific search and Notes dialogs.

### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
None, since mínimum versión for this add-on is set to 2025.2, and this behavior is expected in NVDA for other similar dialogs.